### PR TITLE
Add CoerceValueCallback support for WPF

### DIFF
--- a/Bindables.Shared/AttributeExtensions.cs
+++ b/Bindables.Shared/AttributeExtensions.cs
@@ -17,6 +17,12 @@ public static class AttributeExtensions
 		TypedConstant typedConstant = attributeData.NamedArguments.SingleOrDefault(x => x.Key == "OnPropertyChanged").Value;
 		return typedConstant.Value?.ToString();
 	}
+	
+	public static string? GetOnCoerceValueMethod(this AttributeData attributeData)
+	{
+		TypedConstant typedConstant = attributeData.NamedArguments.SingleOrDefault(x => x.Key == "OnCoerceValue").Value;
+		return typedConstant.Value?.ToString();
+	}
 
 	public static string? GetDefaultValueField(this AttributeData attributeData)
 	{

--- a/Bindables.Shared/Diagnostics.cs
+++ b/Bindables.Shared/Diagnostics.cs
@@ -71,7 +71,23 @@ public class Diagnostics
 	public static readonly DiagnosticDescriptor IncorrectPropertyChangedMethodSignature = new(
 		"BN009",
 		"Incorrect PropertyChanged method signature",
-		"The signature of method '{0}' has to be 'static void {0}(DependencyObject, DependencyPropertyChangedEventArgs)'",
+		"The signature of method '{0}.{1}' has to be 'static void {1}(DependencyObject, DependencyPropertyChangedEventArgs)'",
+		"Code Generation",
+		DiagnosticSeverity.Error,
+		true);
+
+	public static readonly DiagnosticDescriptor MissingCoerceValueMethod = new(
+		"BN008",
+		"Missing CoerceValue method",
+		"The coerce value callback method 'static void {0}(DependencyObject, object)' is not found",
+		"Code Generation",
+		DiagnosticSeverity.Error,
+		true);
+
+	public static readonly DiagnosticDescriptor IncorrectCoerceValueMethodSignature = new(
+		"BN009",
+		"Incorrect CoerceValue method signature",
+		"The signature of method '{0}.{1}' has to be 'static object {1}(DependencyObject, object)'",
 		"Code Generation",
 		DiagnosticSeverity.Error,
 		true);

--- a/Bindables.Wpf.Test/AttachedProperty/ReadOnlyProperty.cs
+++ b/Bindables.Wpf.Test/AttachedProperty/ReadOnlyProperty.cs
@@ -46,7 +46,7 @@ namespace Test
                 ""Example"",
                 typeof(int),
                 typeof(WpfClass),
-                new PropertyMetadata());
+                new FrameworkPropertyMetadata());
             
             ExampleProperty = ExamplePropertyKey.DependencyProperty;
             

--- a/Bindables.Wpf.Test/AttachedProperty/SimpleProperty.cs
+++ b/Bindables.Wpf.Test/AttachedProperty/SimpleProperty.cs
@@ -13,7 +13,7 @@ using Bindables.Wpf;
 
 public partial class WpfClass
 {
-    private static readonly string DefaultValue = ""Test"";
+	private static readonly string DefaultValue = ""Test"";
 
 	[AttachedProperty(typeof(int))]
 	public static readonly DependencyProperty Example1Property;
@@ -33,9 +33,32 @@ public partial class WpfClass
 	[AttachedProperty(typeof(string), OnPropertyChanged = nameof(PropertyChangedCallback), DefaultValueField = nameof(DefaultValue), Options = FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)]
 	public static readonly DependencyProperty Example6Property;
 
-    private static void PropertyChangedCallback(DependencyObject obj, DependencyPropertyChangedEventArgs args)
-    {
-    }
+	[AttachedProperty(typeof(int), OnCoerceValue = nameof(CoerceValueCallback))]
+	public static readonly DependencyProperty Example7Property;
+
+	[AttachedProperty(typeof(int), OnPropertyChanged = nameof(PropertyChangedCallback), OnCoerceValue = nameof(CoerceValueCallback))]
+	public static readonly DependencyProperty Example8Property;
+
+	[AttachedProperty(typeof(string), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue))]
+	public static readonly DependencyProperty Example9Property;
+
+	[AttachedProperty(typeof(string), OnPropertyChanged = nameof(PropertyChangedCallback), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue))]
+	public static readonly DependencyProperty Example10Property;
+
+	[AttachedProperty(typeof(string), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue), Options = FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)]
+	public static readonly DependencyProperty Example11Property;
+
+	[AttachedProperty(typeof(string), OnPropertyChanged = nameof(PropertyChangedCallback), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue), Options = FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)]
+	public static readonly DependencyProperty Example12Property;
+
+	private static void PropertyChangedCallback(DependencyObject obj, DependencyPropertyChangedEventArgs args)
+	{
+	}
+
+	private static object CoerceValueCallback(DependencyObject obj, object value)
+	{
+		return """";
+	}
 }";
 
 	private const string ExpectedSourceCode = @"
@@ -104,25 +127,85 @@ public partial class WpfClass
         target.SetValue(Example6Property, value);
     }
 
+    public static int GetExample7(DependencyObject target)
+    {
+        return (int)target.GetValue(Example7Property);
+    }
+
+    public static void SetExample7(DependencyObject target, int value)
+    {
+        target.SetValue(Example7Property, value);
+    }
+
+    public static int GetExample8(DependencyObject target)
+    {
+        return (int)target.GetValue(Example8Property);
+    }
+
+    public static void SetExample8(DependencyObject target, int value)
+    {
+        target.SetValue(Example8Property, value);
+    }
+
+    public static string GetExample9(DependencyObject target)
+    {
+        return (string)target.GetValue(Example9Property);
+    }
+
+    public static void SetExample9(DependencyObject target, string value)
+    {
+        target.SetValue(Example9Property, value);
+    }
+
+    public static string GetExample10(DependencyObject target)
+    {
+        return (string)target.GetValue(Example10Property);
+    }
+
+    public static void SetExample10(DependencyObject target, string value)
+    {
+        target.SetValue(Example10Property, value);
+    }
+
+    public static string GetExample11(DependencyObject target)
+    {
+        return (string)target.GetValue(Example11Property);
+    }
+
+    public static void SetExample11(DependencyObject target, string value)
+    {
+        target.SetValue(Example11Property, value);
+    }
+
+    public static string GetExample12(DependencyObject target)
+    {
+        return (string)target.GetValue(Example12Property);
+    }
+
+    public static void SetExample12(DependencyObject target, string value)
+    {
+        target.SetValue(Example12Property, value);
+    }
+
     static WpfClass()
     {
         Example1Property = DependencyProperty.RegisterAttached(
             ""Example1"",
             typeof(int),
             typeof(WpfClass),
-            new PropertyMetadata());
+            new FrameworkPropertyMetadata());
         
         Example2Property = DependencyProperty.RegisterAttached(
             ""Example2"",
             typeof(int),
             typeof(WpfClass),
-            new PropertyMetadata(PropertyChangedCallback));
+            new FrameworkPropertyMetadata(PropertyChangedCallback));
         
         Example3Property = DependencyProperty.RegisterAttached(
             ""Example3"",
             typeof(string),
             typeof(WpfClass),
-            new PropertyMetadata(DefaultValue));
+            new FrameworkPropertyMetadata(DefaultValue));
         
         Example4Property = DependencyProperty.RegisterAttached(
             ""Example4"",
@@ -134,13 +217,49 @@ public partial class WpfClass
             ""Example5"",
             typeof(string),
             typeof(WpfClass),
-            new PropertyMetadata(DefaultValue, PropertyChangedCallback));
+            new FrameworkPropertyMetadata(DefaultValue, PropertyChangedCallback));
         
         Example6Property = DependencyProperty.RegisterAttached(
             ""Example6"",
             typeof(string),
             typeof(WpfClass),
             new FrameworkPropertyMetadata(DefaultValue, (FrameworkPropertyMetadataOptions)256, PropertyChangedCallback));
+        
+        Example7Property = DependencyProperty.RegisterAttached(
+            ""Example7"",
+            typeof(int),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(default, CoerceValueCallback));
+        
+        Example8Property = DependencyProperty.RegisterAttached(
+            ""Example8"",
+            typeof(int),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(PropertyChangedCallback, CoerceValueCallback));
+        
+        Example9Property = DependencyProperty.RegisterAttached(
+            ""Example9"",
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, default, CoerceValueCallback));
+        
+        Example10Property = DependencyProperty.RegisterAttached(
+            ""Example10"",
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, PropertyChangedCallback, CoerceValueCallback));
+        
+        Example11Property = DependencyProperty.RegisterAttached(
+            ""Example11"",
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, (FrameworkPropertyMetadataOptions)256, default, CoerceValueCallback));
+        
+        Example12Property = DependencyProperty.RegisterAttached(
+            ""Example12"",
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, (FrameworkPropertyMetadataOptions)256, PropertyChangedCallback, CoerceValueCallback));
         
     }
 }";

--- a/Bindables.Wpf.Test/DependencyProperty/ReadOnlyProperty.cs
+++ b/Bindables.Wpf.Test/DependencyProperty/ReadOnlyProperty.cs
@@ -42,7 +42,7 @@ namespace Test
                 nameof(Example),
                 typeof(int),
                 typeof(WpfClass),
-                new PropertyMetadata());
+                new FrameworkPropertyMetadata());
             
             ExampleProperty = ExamplePropertyKey.DependencyProperty;
             

--- a/Bindables.Wpf.Test/DependencyProperty/SimpleProperty.cs
+++ b/Bindables.Wpf.Test/DependencyProperty/SimpleProperty.cs
@@ -13,7 +13,7 @@ using Bindables.Wpf;
 
 public partial class WpfClass : DependencyObject
 {
-    private static readonly string DefaultValue = ""Test"";
+	private static readonly string DefaultValue = ""Test"";
 
 	[DependencyProperty(typeof(int))]
 	public static readonly DependencyProperty Example1Property;
@@ -33,9 +33,32 @@ public partial class WpfClass : DependencyObject
 	[DependencyProperty(typeof(string), OnPropertyChanged = nameof(PropertyChangedCallback), DefaultValueField = nameof(DefaultValue), Options = FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)]
 	public static readonly DependencyProperty Example6Property;
 
+	[DependencyProperty(typeof(int), OnCoerceValue = nameof(CoerceValueCallback))]
+	public static readonly DependencyProperty Example7Property;
+
+	[DependencyProperty(typeof(int), OnPropertyChanged = nameof(PropertyChangedCallback), OnCoerceValue = nameof(CoerceValueCallback))]
+	public static readonly DependencyProperty Example8Property;
+
+	[DependencyProperty(typeof(string), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue))]
+	public static readonly DependencyProperty Example9Property;
+
+	[DependencyProperty(typeof(string), OnPropertyChanged = nameof(PropertyChangedCallback), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue))]
+	public static readonly DependencyProperty Example10Property;
+
+	[DependencyProperty(typeof(string), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue), Options = FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)]
+	public static readonly DependencyProperty Example11Property;
+
+	[DependencyProperty(typeof(string), OnPropertyChanged = nameof(PropertyChangedCallback), OnCoerceValue = nameof(CoerceValueCallback), DefaultValueField = nameof(DefaultValue), Options = FrameworkPropertyMetadataOptions.BindsTwoWayByDefault)]
+	public static readonly DependencyProperty Example12Property;
+
     private static void PropertyChangedCallback(DependencyObject obj, DependencyPropertyChangedEventArgs args)
     {
     }
+
+	private static object CoerceValueCallback(DependencyObject obj, object value)
+	{
+		return """";
+	}
 }";
 
 	private const string ExpectedSourceCode = @"
@@ -80,25 +103,61 @@ public partial class WpfClass
         set => SetValue(Example6Property, value);
     }
 
+    public int Example7
+    {
+        get => (int)GetValue(Example7Property);
+        set => SetValue(Example7Property, value);
+    }
+
+    public int Example8
+    {
+        get => (int)GetValue(Example8Property);
+        set => SetValue(Example8Property, value);
+    }
+
+    public string Example9
+    {
+        get => (string)GetValue(Example9Property);
+        set => SetValue(Example9Property, value);
+    }
+
+    public string Example10
+    {
+        get => (string)GetValue(Example10Property);
+        set => SetValue(Example10Property, value);
+    }
+
+    public string Example11
+    {
+        get => (string)GetValue(Example11Property);
+        set => SetValue(Example11Property, value);
+    }
+
+    public string Example12
+    {
+        get => (string)GetValue(Example12Property);
+        set => SetValue(Example12Property, value);
+    }
+
     static WpfClass()
     {
         Example1Property = DependencyProperty.Register(
             nameof(Example1),
             typeof(int),
             typeof(WpfClass),
-            new PropertyMetadata());
+            new FrameworkPropertyMetadata());
         
         Example2Property = DependencyProperty.Register(
             nameof(Example2),
             typeof(int),
             typeof(WpfClass),
-            new PropertyMetadata(PropertyChangedCallback));
+            new FrameworkPropertyMetadata(PropertyChangedCallback));
         
         Example3Property = DependencyProperty.Register(
             nameof(Example3),
             typeof(string),
             typeof(WpfClass),
-            new PropertyMetadata(DefaultValue));
+            new FrameworkPropertyMetadata(DefaultValue));
         
         Example4Property = DependencyProperty.Register(
             nameof(Example4),
@@ -110,13 +169,49 @@ public partial class WpfClass
             nameof(Example5),
             typeof(string),
             typeof(WpfClass),
-            new PropertyMetadata(DefaultValue, PropertyChangedCallback));
+            new FrameworkPropertyMetadata(DefaultValue, PropertyChangedCallback));
         
         Example6Property = DependencyProperty.Register(
             nameof(Example6),
             typeof(string),
             typeof(WpfClass),
             new FrameworkPropertyMetadata(DefaultValue, (FrameworkPropertyMetadataOptions)256, PropertyChangedCallback));
+        
+        Example7Property = DependencyProperty.Register(
+            nameof(Example7),
+            typeof(int),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(default, CoerceValueCallback));
+        
+        Example8Property = DependencyProperty.Register(
+            nameof(Example8),
+            typeof(int),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(PropertyChangedCallback, CoerceValueCallback));
+        
+        Example9Property = DependencyProperty.Register(
+            nameof(Example9),
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, default, CoerceValueCallback));
+        
+        Example10Property = DependencyProperty.Register(
+            nameof(Example10),
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, PropertyChangedCallback, CoerceValueCallback));
+        
+        Example11Property = DependencyProperty.Register(
+            nameof(Example11),
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, (FrameworkPropertyMetadataOptions)256, default, CoerceValueCallback));
+        
+        Example12Property = DependencyProperty.Register(
+            nameof(Example12),
+            typeof(string),
+            typeof(WpfClass),
+            new FrameworkPropertyMetadata(DefaultValue, (FrameworkPropertyMetadataOptions)256, PropertyChangedCallback, CoerceValueCallback));
         
     }
 }";

--- a/Bindables.Wpf/AttachedPropertyGenerator.cs
+++ b/Bindables.Wpf/AttachedPropertyGenerator.cs
@@ -29,12 +29,19 @@ public class AttachedPropertyGenerator : WindowsPropertyGenerator
 			"System.Windows.DependencyPropertyChangedEventArgs"
 		};
 
+		string[] coerceValueMethodParameterTypes =
+		{
+			"System.Windows.DependencyObject",
+			"object",
+		};
+
 		CheckResult result = CheckResult.Valid;
 
 		result = result.Combine(CheckThatStaticConstructorDoesNotExist(context, classSymbol));
 		result = result.Combine(CheckThatClassIsPartial(context, classSymbol));
 		result = result.Combine(CheckFieldTypeAndName(context, fieldSymbol, fieldTypeAndNameConditions));
 		result = result.Combine(CheckPropertyChangedMethodSignature(context, classSymbol, fieldSymbol, attributeSymbol, propertyChangedMethodParameterTypes));
+		result = result.Combine(CheckCoerceValueMethodSignature(context, classSymbol, fieldSymbol, attributeSymbol, coerceValueMethodParameterTypes));
 		result = result.Combine(CheckDefaultValueField(context, classSymbol, fieldSymbol, attributeSymbol));
 
 		return result;

--- a/Bindables.Wpf/DependencyPropertyGenerator.cs
+++ b/Bindables.Wpf/DependencyPropertyGenerator.cs
@@ -28,6 +28,12 @@ public class DependencyPropertyGenerator : WindowsPropertyGenerator
 			"System.Windows.DependencyPropertyChangedEventArgs"
 		};
 
+		string[] coerceValueMethodParameterTypes =
+		{
+			"System.Windows.DependencyObject",
+			"object",
+		};
+
 		CheckResult result = CheckResult.Valid;
 
 		result = result.Combine(CheckThatClassHasBaseType(context, classSymbol, "System.Windows.DependencyObject", Diagnostics.ClassDoesNotInheritFromDependencyObject));
@@ -35,6 +41,7 @@ public class DependencyPropertyGenerator : WindowsPropertyGenerator
 		result = result.Combine(CheckThatClassIsPartial(context, classSymbol));
 		result = result.Combine(CheckFieldTypeAndName(context, fieldSymbol, fieldTypeAndNameConditions));
 		result = result.Combine(CheckPropertyChangedMethodSignature(context, classSymbol, fieldSymbol, attributeSymbol, propertyChangedMethodParameterTypes));
+		result = result.Combine(CheckCoerceValueMethodSignature(context, classSymbol, fieldSymbol, attributeSymbol, coerceValueMethodParameterTypes));
 		result = result.Combine(CheckDefaultValueField(context, classSymbol, fieldSymbol, attributeSymbol));
 
 		return result;

--- a/Bindables.Wpf/WindowsPropertyGenerator.cs
+++ b/Bindables.Wpf/WindowsPropertyGenerator.cs
@@ -21,6 +21,7 @@ namespace Bindables.Wpf
     {{
         public Type PropertyType {{ get; }}
         public string? OnPropertyChanged {{ get; set; }}
+		public string? OnCoerceValue {{ get; set; }}
         public string? DefaultValueField {{ get; set; }}
         public FrameworkPropertyMetadataOptions Options {{ get; set; }}
 
@@ -35,47 +36,33 @@ namespace Bindables.Wpf
 	protected string GetMetadataDefinition(AttributeData attributeData)
 	{
 		string? propertyChangedMethod = attributeData.GetOnPropertyChangedMethod();
+		string? coerceValueMethod = attributeData.GetOnCoerceValueMethod();
 		string? defaultValueField = attributeData.GetDefaultValueField();
 		string? options = attributeData.GetFrameworkPropertyMetadataOptions();
 
-		if (propertyChangedMethod == null && defaultValueField == null && options == null)
-		{
-			return "new PropertyMetadata()";
-		}
+		string[] args = new string[4];
+		int count = 0;
 
-		string definition = options == null
-			? "new PropertyMetadata("
-			: "new FrameworkPropertyMetadata(";
-
-		if (defaultValueField != null)
+		if (defaultValueField != null || options != null)
 		{
-			definition += defaultValueField;
+			args[count++] = defaultValueField ?? "default";
 		}
 
 		if (options != null)
 		{
-			if (defaultValueField == null)
-			{
-				definition += "default";
-			}
-
-			definition += ", ";
-			definition += $"(FrameworkPropertyMetadataOptions){options}";
+			args[count++] = $"(FrameworkPropertyMetadataOptions){options}";
 		}
 
-		if (propertyChangedMethod != null)
+		if (propertyChangedMethod != null || coerceValueMethod != null)
 		{
-			if (defaultValueField != null || options != null)
-			{
-				definition += ", ";
-			}
-
-			definition += propertyChangedMethod;
+			args[count++] = propertyChangedMethod ?? "default";
 		}
 
-		definition += ")";
+		if (coerceValueMethod != null)
+		{
+			args[count++] = coerceValueMethod;
+		}
 
-
-		return definition;
+		return $"new FrameworkPropertyMetadata({string.Join(", ", args, 0, count)})";
 	}
 }

--- a/Bindables.Wpf/WindowsPropertyGenerator.cs
+++ b/Bindables.Wpf/WindowsPropertyGenerator.cs
@@ -21,7 +21,7 @@ namespace Bindables.Wpf
     {{
         public Type PropertyType {{ get; }}
         public string? OnPropertyChanged {{ get; set; }}
-		public string? OnCoerceValue {{ get; set; }}
+        public string? OnCoerceValue {{ get; set; }}
         public string? DefaultValueField {{ get; set; }}
         public FrameworkPropertyMetadataOptions Options {{ get; set; }}
 


### PR DESCRIPTION
Fixes #23

I don't know Forms at all, so if there is equivalent functionality I can't provide it.

Explanations for a couple of cosmetic changes:

1. Code always uses `FrameworkPropertyMetadata`. This is not only pretty much expected for WPF projects[^1], but it also provides a few extra constructors that only require the callbacks, which allows for tidy code generation.
2. I changed some of the diagnostics, because it was providing misleading information by outputting the class name twice instead of the method name.
3. The various permutations of constructors are cleanly handled by adding to a simple array and joining the result. I hope this is a reasonable approach for you.

[^1]: See remarks in the official documentation: https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkpropertymetadata?view=windowsdesktop-6.0#remarks