### PR TITLE
Issue #30: added GeneratedCodeAttribute to generated code

### DIFF
--- a/Bindables.Forms/FormsPropertyGenerator.cs
+++ b/Bindables.Forms/FormsPropertyGenerator.cs
@@ -8,4 +8,7 @@ public class FormsPropertyGenerator : XamarinPropertyGenerator
 {
 	public sealed override string AttributeNamespace => "Bindables.Forms";
 	public sealed override string PlatformNamespace => "Xamarin.Forms";
+	public sealed override string GeneratorName => typeof(FormsPropertyGenerator).FullName ??
+	                                               $"{AttributeNamespace}.{nameof(FormsPropertyGenerator)}";
+	public sealed override string GeneratorVersion => typeof(FormsPropertyGenerator).Assembly.GetName().Version.ToString();
 }

--- a/Bindables.Maui/MauiPropertyGenerator.cs
+++ b/Bindables.Maui/MauiPropertyGenerator.cs
@@ -8,4 +8,7 @@ public class MauiPropertyGenerator : XamarinPropertyGenerator
 {
 	public sealed override string AttributeNamespace => "Bindables.Maui";
 	public sealed override string PlatformNamespace => "Microsoft.Maui.Controls";
+	public sealed override string GeneratorName => typeof(MauiPropertyGenerator).FullName ??
+	                                               $"{AttributeNamespace}.{nameof(MauiPropertyGenerator)}";
+	public sealed override string GeneratorVersion => typeof(MauiPropertyGenerator).Assembly.GetName().Version.ToString();
 }

--- a/Bindables.Shared.Test.Windows/ReadOnlyProperty.cs
+++ b/Bindables.Shared.Test.Windows/ReadOnlyProperty.cs
@@ -40,46 +40,57 @@ namespace Test
 {{
     public partial class ExampleClass
     {{
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example1Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public int Example1
         {{
             get => (int)GetValue(Example1Property);
             private set => SetValue(Example1PropertyKey, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example2Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public string? Example2
         {{
             get => (string?)GetValue(Example2Property);
             private set => SetValue(Example2PropertyKey, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example3Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static int GetExample3({BaseClassName} target)
         {{
             return (int)target.GetValue(Example3Property);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         private static void SetExample3({BaseClassName} target, int value)
         {{
             target.SetValue(Example3Property, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example4Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static string? GetExample4({BaseClassName} target)
         {{
             return (string?)target.GetValue(Example4Property);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         private static void SetExample4({BaseClassName} target, string? value)
         {{
             target.SetValue(Example4Property, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         static ExampleClass()
         {{
             Example1PropertyKey = {DependencyPropertyName}.RegisterReadOnly(

--- a/Bindables.Shared.Test.Windows/RegularProperty.cs
+++ b/Bindables.Shared.Test.Windows/RegularProperty.cs
@@ -119,198 +119,235 @@ using {PlatformNamespace};
 
 public partial class ExampleClass
 {{
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public int Example1
     {{
         get => (int)GetValue(Example1Property);
         set => SetValue(Example1Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public int Example2
     {{
         get => (int)GetValue(Example2Property);
         set => SetValue(Example2Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example3
     {{
         get => (string?)GetValue(Example3Property);
         set => SetValue(Example3Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example4
     {{
         get => (string?)GetValue(Example4Property);
         set => SetValue(Example4Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example5
     {{
         get => (string?)GetValue(Example5Property);
         set => SetValue(Example5Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example6
     {{
         get => (string?)GetValue(Example6Property);
         set => SetValue(Example6Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public int Example7
     {{
         get => (int)GetValue(Example7Property);
         set => SetValue(Example7Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public int Example8
     {{
         get => (int)GetValue(Example8Property);
         set => SetValue(Example8Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example9
     {{
         get => (string?)GetValue(Example9Property);
         set => SetValue(Example9Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example10
     {{
         get => (string?)GetValue(Example10Property);
         set => SetValue(Example10Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example11
     {{
         get => (string?)GetValue(Example11Property);
         set => SetValue(Example11Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example12
     {{
         get => (string?)GetValue(Example12Property);
         set => SetValue(Example12Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static int GetExampleAttached1({BaseClassName} target)
     {{
         return (int)target.GetValue(ExampleAttached1Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached1({BaseClassName} target, int value)
     {{
         target.SetValue(ExampleAttached1Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static int GetExampleAttached2({BaseClassName} target)
     {{
         return (int)target.GetValue(ExampleAttached2Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached2({BaseClassName} target, int value)
     {{
         target.SetValue(ExampleAttached2Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached3({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached3Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached3({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached3Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached4({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached4Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached4({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached4Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached5({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached5Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached5({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached5Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached6({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached6Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached6({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached6Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static int GetExampleAttached7({BaseClassName} target)
     {{
         return (int)target.GetValue(ExampleAttached7Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached7({BaseClassName} target, int value)
     {{
         target.SetValue(ExampleAttached7Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static int GetExampleAttached8({BaseClassName} target)
     {{
         return (int)target.GetValue(ExampleAttached8Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached8({BaseClassName} target, int value)
     {{
         target.SetValue(ExampleAttached8Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached9({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached9Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached9({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached9Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached10({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached10Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached10({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached10Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached11({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached11Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached11({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached11Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached12({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached12Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached12({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached12Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     static ExampleClass()
     {{
         Example1Property = {DependencyPropertyName}.Register(

--- a/Bindables.Shared.Test.Xamarin/ReadOnlyProperty.cs
+++ b/Bindables.Shared.Test.Xamarin/ReadOnlyProperty.cs
@@ -40,46 +40,57 @@ namespace Test
 {{
     public partial class ExampleClass
     {{
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example1Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public int Example1
         {{
             get => (int)GetValue(Example1Property);
             private set => SetValue(Example1PropertyKey, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example2Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public string? Example2
         {{
             get => (string?)GetValue(Example2Property);
             private set => SetValue(Example2PropertyKey, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example3Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static int GetExample3({BaseClassName} target)
         {{
             return (int)target.GetValue(Example3Property);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         private static void SetExample3({BaseClassName} target, int value)
         {{
             target.SetValue(Example3Property, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static readonly {DependencyPropertyName} Example4Property;
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         public static string? GetExample4({BaseClassName} target)
         {{
             return (string?)target.GetValue(Example4Property);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         private static void SetExample4({BaseClassName} target, string? value)
         {{
             target.SetValue(Example4Property, value);
         }}
 
+        [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
         static ExampleClass()
         {{
             Example1PropertyKey = {DependencyPropertyName}.CreateReadOnly(

--- a/Bindables.Shared.Test.Xamarin/RegularProperty.cs
+++ b/Bindables.Shared.Test.Xamarin/RegularProperty.cs
@@ -73,102 +73,121 @@ using {PlatformNamespace};
 
 public partial class ExampleClass
 {{
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public int Example1
     {{
         get => (int)GetValue(Example1Property);
         set => SetValue(Example1Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public int Example2
     {{
         get => (int)GetValue(Example2Property);
         set => SetValue(Example2Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example3
     {{
         get => (string?)GetValue(Example3Property);
         set => SetValue(Example3Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example4
     {{
         get => (string?)GetValue(Example4Property);
         set => SetValue(Example4Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example5
     {{
         get => (string?)GetValue(Example5Property);
         set => SetValue(Example5Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public string? Example6
     {{
         get => (string?)GetValue(Example6Property);
         set => SetValue(Example6Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static int GetExampleAttached1({BaseClassName} target)
     {{
         return (int)target.GetValue(ExampleAttached1Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached1({BaseClassName} target, int value)
     {{
         target.SetValue(ExampleAttached1Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static int GetExampleAttached2({BaseClassName} target)
     {{
         return (int)target.GetValue(ExampleAttached2Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached2({BaseClassName} target, int value)
     {{
         target.SetValue(ExampleAttached2Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached3({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached3Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached3({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached3Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached4({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached4Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached4({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached4Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached5({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached5Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached5({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached5Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static string? GetExampleAttached6({BaseClassName} target)
     {{
         return (string?)target.GetValue(ExampleAttached6Property);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     public static void SetExampleAttached6({BaseClassName} target, string? value)
     {{
         target.SetValue(ExampleAttached6Property, value);
     }}
 
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     static ExampleClass()
     {{
         Example1Property = {DependencyPropertyName}.Create(

--- a/Bindables.Shared.Test/TestBase.cs
+++ b/Bindables.Shared.Test/TestBase.cs
@@ -20,6 +20,8 @@ public abstract partial class TestBase<T> where T : PropertyGeneratorBase, new()
 	public string AttachedPropertyAttributeName => Generator.AttachedPropertyAttributeName;
 	public string BaseClassName => Generator.BaseClassName;
 	public string DerivedFromBaseClassName => Generator.DerivedFromBaseClassName;
+	public string GeneratorName => Generator.GeneratorName;
+	public string GeneratorVersion => Generator.GeneratorVersion;
 	public string DependencyPropertyName => Generator.DependencyPropertyName;
 	public string DependencyPropertyKeyName => Generator.DependencyPropertyKeyName;
 	public IReadOnlyList<string> PropertyChangedMethodParameterTypes => Generator.PropertyChangedMethodParameterTypes;

--- a/Bindables.Shared.Windows/WindowsPropertyGenerator.cs
+++ b/Bindables.Shared.Windows/WindowsPropertyGenerator.cs
@@ -53,6 +53,7 @@ using {PlatformNamespace};
 
 namespace {AttributeNamespace}
 {{
+	[global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     [AttributeUsage(AttributeTargets.Field)]
     internal class {attributeName} : Attribute
     {{

--- a/Bindables.Shared.Xamarin/XamarinPropertyGenerator.cs
+++ b/Bindables.Shared.Xamarin/XamarinPropertyGenerator.cs
@@ -54,6 +54,7 @@ using {PlatformNamespace};
 
 namespace {AttributeNamespace}
 {{
+    [global::System.CodeDom.Compiler.GeneratedCode(""{GeneratorName}"", ""{GeneratorVersion}"")]
     [AttributeUsage(AttributeTargets.Field)]
     internal class {attributeName} : Attribute
     {{

--- a/Bindables.Shared/PropertyGeneratorBase.cs
+++ b/Bindables.Shared/PropertyGeneratorBase.cs
@@ -21,6 +21,8 @@ public abstract class PropertyGeneratorBase : IIncrementalGenerator
 	public abstract string RegisterReadOnlyMethod { get; }
 	public abstract string RegisterAttachedMethod { get; }
 	public abstract string RegisterAttachedReadOnlyMethod { get; }
+	public abstract string GeneratorName { get; }
+	public abstract string GeneratorVersion { get; }
 
 	public abstract IReadOnlyList<string> PropertyChangedMethodParameterTypes { get; }
 	public abstract IReadOnlyList<string> CoerceValueMethodParameterTypes { get; }
@@ -245,6 +247,7 @@ public abstract class PropertyGeneratorBase : IIncrementalGenerator
 			field.FieldProcessor.Process(builder, classSymbol, field, initializationLines);
 		}
 
+		builder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\", \"{GeneratorVersion}\")]");
 		builder.AppendLine($"static {classSymbol.Name}()");
 		builder.OpenScope();
 
@@ -328,6 +331,7 @@ public abstract class PropertyGeneratorBase : IIncrementalGenerator
 		string maybeNullPropertyTypeName = propertyType.ToDisplayString(NullableFlowState.MaybeNull);
 		string propertyTypeName = propertyType.ToDisplayString();
 
+		builder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\", \"{GeneratorVersion}\")]");
 		builder.AppendLine($"public static readonly {DependencyPropertyName} {propertyName}Property;");
 		builder.AppendLine();
 
@@ -410,6 +414,7 @@ public abstract class PropertyGeneratorBase : IIncrementalGenerator
 		string maybeNullPropertyTypeName = propertyType.ToDisplayString(NullableFlowState.MaybeNull);
 		string propertyTypeName = propertyType.ToDisplayString();
 
+		builder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\", \"{GeneratorVersion}\")]");
 		builder.AppendLine($"public static readonly {DependencyPropertyName} {propertyName}Property;");
 		builder.AppendLine();
 
@@ -442,6 +447,7 @@ public abstract class PropertyGeneratorBase : IIncrementalGenerator
 		// Do not append visibility if it is public.
 		fieldVisibility = fieldVisibility.Replace("public", "");
 
+		builder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\", \"{GeneratorVersion}\")]");
 		builder.AppendLine($"public {propertyTypeName} {propertyName}");
 		builder.OpenScope();
 
@@ -486,6 +492,7 @@ public abstract class PropertyGeneratorBase : IIncrementalGenerator
 		string propertyName,
 		string fieldVisibility)
 	{
+		builder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\", \"{GeneratorVersion}\")]");
 		builder.AppendLine($"public static {propertyTypeName} Get{propertyName}({BaseClassName} target)");
 		builder.OpenScope();
 
@@ -494,6 +501,7 @@ public abstract class PropertyGeneratorBase : IIncrementalGenerator
 		builder.CloseScope();
 		builder.AppendLine();
 
+		builder.AppendLine($"[global::System.CodeDom.Compiler.GeneratedCode(\"{GeneratorName}\", \"{GeneratorVersion}\")]");
 		builder.AppendLine($"{fieldVisibility} static void Set{propertyName}({BaseClassName} target, {propertyTypeName} value)");
 		builder.OpenScope();
 

--- a/Bindables.Wpf/WpfPropertyGenerator.cs
+++ b/Bindables.Wpf/WpfPropertyGenerator.cs
@@ -8,4 +8,7 @@ public class WpfPropertyGenerator : WindowsPropertyGenerator
 {
 	public sealed override string AttributeNamespace => "Bindables.Wpf";
 	public sealed override string PlatformNamespace => "System.Windows";
+	public sealed override string GeneratorName => typeof(WpfPropertyGenerator).FullName ??
+	                                               $"{AttributeNamespace}.{nameof(WpfPropertyGenerator)}";
+	public sealed override string GeneratorVersion => typeof(WpfPropertyGenerator).Assembly.GetName().Version.ToString();
 }

--- a/README.md
+++ b/README.md
@@ -94,26 +94,31 @@ using System.Windows;
 
 public partial class YourClass
 {
+    [global::System.CodeDom.Compiler.GeneratedCode("Bindables.Wpf.WpfPropertyGenerator", "1.4.0")]
     public string? Regular
     {
         get => (string?)GetValue(RegularProperty);
         set => SetValue(RegularProperty, value);
     }
 
+    [global::System.CodeDom.Compiler.GeneratedCode("Bindables.Wpf.WpfPropertyGenerator", "1.4.0")]
     public static readonly DependencyProperty ReadOnlyProperty;
 
+    [global::System.CodeDom.Compiler.GeneratedCode("Bindables.Wpf.WpfPropertyGenerator", "1.4.0")]
     public string? ReadOnly
     {
         get => (string?)GetValue(ReadOnlyProperty);
         private set => SetValue(ReadOnlyPropertyKey, value);
     }
 
+    [global::System.CodeDom.Compiler.GeneratedCode("Bindables.Wpf.WpfPropertyGenerator", "1.4.0")]
     public string? Customized
     {
         get => (string?)GetValue(CustomizedProperty);
         set => SetValue(CustomizedProperty, value);
     }
 
+    [global::System.CodeDom.Compiler.GeneratedCode("Bindables.Wpf.WpfPropertyGenerator", "1.4.0")]
     static YourClass()
     {
         RegularProperty = DependencyProperty.Register(


### PR DESCRIPTION
### Description of Change
This adds [GeneratedCodeAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.codedom.compiler.generatedcodeattribute?view=net-7.0) to the generate code. Benefits: generated code is clearly marked as generated code and analysers should not treat it like a code written manually by developers.

### Linked Issues
- Fixes https://github.com/notanaverageman/Bindables/issues/30